### PR TITLE
added build step for metis

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,8 @@
-
+use std::process::Command;
 
 
 fn main() {
-    println!("cargo:rustc-link-search=/home/reidatcheson/Library/metis/lib");
+    let _output = Command::new("sh")
+        .arg("./external/dl_install_metis.sh").output();
+    println!("cargo:rustc-link-search=./external/lib")
 }

--- a/external/clean.sh
+++ b/external/clean.sh
@@ -1,0 +1,9 @@
+this_script=$(realpath $0)
+path=$(dirname $this_script)
+rm -rf $path/install
+rm -rf $path/bin
+rm -rf $path/GKlib
+rm -rf $path/include
+rm -rf $path/intall
+rm -rf $path/lib
+rm -rf $path/METIS

--- a/external/dl_install_metis.sh
+++ b/external/dl_install_metis.sh
@@ -1,0 +1,13 @@
+
+this_script=$(realpath $0)
+path=$(dirname $this_script)
+cd $path
+git clone https://github.com/KarypisLab/GKlib.git
+cd $path/GKlib
+make config cc=gcc prefix=$path
+make install
+cd ..
+git clone https://github.com/KarypisLab/METIS.git
+cd $path/METIS
+make config cc=gcc i64=1 prefix=$path glib_path=$path
+make install

--- a/src/metis.rs
+++ b/src/metis.rs
@@ -5,6 +5,7 @@ use std::fs::File;
 use std::io::Write;
 
 #[link(name = "metis", kind = "static")]
+#[link(name = "GKlib", kind = "static")]
 extern{
     pub fn METIS_ComputeVertexSeparator(nvtxs : *const i64,xadj : *const i64,adjncy : *const i64,
                                     vwgt : *const i64, options : *const i64, sepsize : *mut i64,part : *mut i64) -> i32;


### PR DESCRIPTION
Added _light_ automation to grab and build metis and its dependencies on the host system and then point the linker to those instead of a hardcoded metis.

Not tested on many systems yet.