### PR TITLE
allow to use blas env variable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Reid Atcheson <reid.atcheson@gmail.com>"]
 edition = "2021"
 
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/build.rs
+++ b/build.rs
@@ -4,10 +4,12 @@ use std::env;
 
 fn main() {
     let dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let blas = env::var("BLAS").unwrap();
     let build = Path::new(&dir).join("external").join("dl_install_metis.sh");
     let lib = Path::new(&dir).join("external").join("lib");
-    let _output = Command::new("sh").arg(build.to_str().unwrap()).output().unwrap();
     println!("cargo:rustc-link-search={}",lib.display());
-    println!("cargo:rustc-link-lib=blas");
+    println!("cargo:rustc-link-search={}",blas);
     println!("cargo:rustc-link-lib=lapack");
-}
+    println!("cargo:rustc-link-lib=blas");
+    let _output = Command::new("sh").arg(build.to_str().unwrap()).output().unwrap();
+ }


### PR DESCRIPTION
blas not always in default searchable paths. let user supply environment variable to indicate where blas,lapack are