### PR TITLE
Fixing separator issue

### DIFF
--- a/src/dtree.rs
+++ b/src/dtree.rs
@@ -64,6 +64,11 @@ impl DissectionTree{
                 if ns.len()>maxnodes{
                     let subg=g.subgraph(&ns);
                     let (p1,p2,sep)=subg.split();
+                    if sep.len() == 0{
+                        nodes.push(ns.iter().map(|&x|x as usize).collect());
+                        parents.push(parent);
+                        continue;
+                    }
 
 
                     //The separator goes into the tree

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 extern crate blas;
-//extern crate openblas_src;
+extern crate openblas_src;
 
 pub mod metis;
 pub mod dtree;

--- a/src/metis.rs
+++ b/src/metis.rs
@@ -116,7 +116,6 @@ impl MetisGraph{
             unsafe{ 
                 METIS_ComputeVertexSeparator(&nvtxs,self.xadj.as_ptr(),self.adjncy.as_ptr(),std::ptr::null(),std::ptr::null(),&mut sepsize,part.as_mut_ptr())
             };
-            assert!(sepsize != 0);
             assert!(info != METIS_ERROR_INPUT);
             assert!(info != METIS_ERROR_MEMORY);
             assert!(info != METIS_ERROR);
@@ -128,12 +127,6 @@ impl MetisGraph{
         let p1 : Vec<i64> = part.iter().enumerate().filter(|&(_i,v)| *v == PART1).map(|(i,_v)|i as i64).collect();
         let psep : Vec<i64> = part.iter().enumerate().filter(|&(_i,v)| *v == SEPARATOR).map(|(i,_v)|i as i64).collect();
 
-        //These cases can actually happen in practice
-        //but handling them adds a lot of complications
-        //so for now I panic when they happen.
-        assert!(p0.len()>0);
-        assert!(p1.len()>0);
-        assert!(psep.len()>0);
         assert!(p0.len()+p1.len()+psep.len()==self.xadj.len()-1);
 
         (p0,p1,psep)


### PR DESCRIPTION
The code originally panicked when METIS failed to compute a separator. Now it instead terminates that path of the tree as a leaf, even if it is bigger than the prescribed threshold (so this could result in large dense matrices, but it will fail a lot less often).